### PR TITLE
test and implement #2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "postcss-prefix",
   "version": "1.0.1",
   "dependencies": {
-    "postcss": "^5.0.8"
+    "postcss": "^5.0.8",
+    "postcss-selector-parser": "^1.3.0"
   },
   "devDependencies": {
     "tape": "^4.2.1"

--- a/test/fixture-out.css
+++ b/test/fixture-out.css
@@ -10,6 +10,9 @@
   --color-green: #0f0;
 }
 
+#hello-world { color: green; }
+#hello-world:hover { color: blue; }
+
 #hello-world h1 {}
 #hello-world h1.title {}
 #hello-world h2#thing {}

--- a/test/fixture.css
+++ b/test/fixture.css
@@ -10,6 +10,9 @@
   --color-green: #0f0;
 }
 
+:host { color: green; }
+:host(:hover) { color: blue; }
+
 h1 {}
 h1.title {}
 h2#thing {}

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ test('postcss-prefix', function (t) {
   const expected = fs.readFileSync(path.join(__dirname, 'fixture-out.css'), 'utf8')
   const css = fs.readFileSync(path.join(__dirname, 'fixture.css'), 'utf8')
   const out = postcss()
-    .use(prefix('#hello-world '))
+    .use(prefix('#hello-world'))
     .process(css)
     .toString()
 


### PR DESCRIPTION
given this feature required more advanced manipulation of the selectors, i re-wrote the module using postcss-selector-parser

this led to a breaking change in the API: prefix _must_ be a single node, at the moment either an #id or a .className

thoughts?
