### PR TITLE
Prevent pseudo selector args from prefixing

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,9 @@ function postcssPrefix (prefix, options) {
         // if parent is not selector and
         selector.parent.type !== 'selector' ||
         // if not first node in container
-        selector.parent.nodes[0] !== selector
+        selector.parent.nodes[0] !== selector ||
+        // don't prefix pseudo selector args unless it's `:not`
+        (selector.parent.parent.type === 'pseudo' && selector.parent.parent.value !== ':not')
       ) return
 
       const prefixNode = getPrefixNode(prefix)

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   },
   "devDependencies": {
     "tape": "^4.2.1"
+  },
+  "scripts": {
+    "test": "tape test/index.js"
   }
 }

--- a/test/fixture-out.css
+++ b/test/fixture-out.css
@@ -23,3 +23,13 @@
 @media screen and (max-width: 42rem) {
   #hello-world #another .thing > x-here {}
 }
+
+#hello-world .stuff:nth-child(even) {}
+
+#hello-world .stuff:nth-last-child(even) {}
+
+#hello-world .stuff:nth-of-type(2) {}
+
+#hello-world .stuff:nth-last-of-type(2) {}
+
+#hello-world .stuff:not(#hello-world p) {}

--- a/test/fixture.css
+++ b/test/fixture.css
@@ -23,3 +23,13 @@ h2#thing {}
 @media screen and (max-width: 42rem) {
   #another .thing > x-here {}
 }
+
+.stuff:nth-child(even) {}
+
+.stuff:nth-last-child(even) {}
+
+.stuff:nth-of-type(2) {}
+
+.stuff:nth-last-of-type(2) {}
+
+.stuff:not(p) {}


### PR DESCRIPTION
This change prevents the argument to a pseudo selector from being prefixed
(since it shouldn't be!).

Also added provisions to run the tests via `npm test`

I'm not sure if this is the best way to solve this, but it does fix #4.

We might not care that the first parent selector is a `selector` and only need to determine if the parent's parent is a `pseudo` selector.

I still feel like this might be a bug in the parser, however, it's late and I don't have time to delve into that :)
