### PR TITLE
Ignore keyframes when prefixing

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ function postcssPrefix (prefix, options) {
 
   return function (root) {
     root.walkRules(function (rule) {
+      if (rule.parent && rule.parent.type === 'atrule' &&
+          rule.parent.name.indexOf('keyframes') !== -1) {
+        return
+      }
+
       const selector = Selector(
         transformSelectors
       ).process(rule.selector).result

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,17 @@ test('postcss-prefix', function (t) {
     .process(css)
     .toString()
 
-  t.equal(expected, out, 'output is as expected')
+  t.equal(out, expected, 'output is as expected')
+  t.end()
+})
+
+test('postcss-prefix: keyframes ignored', function (t) {
+  const css = fs.readFileSync(path.join(__dirname, 'keyframe.css'), 'utf8')
+  const out = postcss()
+    .use(prefix('#key'))
+    .process(css)
+    .toString()
+
+  t.equal(out, css, 'keyframes are not prefixed')
   t.end()
 })

--- a/test/keyframe.css
+++ b/test/keyframe.css
@@ -1,0 +1,17 @@
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
Before, keyframe rules would be prefixed, and become invalid css:

```
@keyframes animation {
  .prefix from {
  }
  .prefix to {
  }
}
```

Now, keyframes are ignored when prefixing.
