### PR TITLE
feat(prefix): drop support for non :host prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# postcss-prefix
+Replace `:host` elements with a prefix of your choosing
+
+## Usage
+```js
+const prefix = require('postcss-prefix')
+const postcss = require('postcss')
+
+const css = `
+  :host { color: blue }
+  .hello { color: black }
+`
+
+const newCss = postcss()
+  .use(prefix('#hello-world'))
+  .process(css)
+  .toString()
+
+console.log(newCss)
+// => #hello-world { color: blue }
+// => .hello { color: black }
+`
+```
+
+## See Also
+- [sheetify](https://github.com/stackcss/sheetify)
+
+## License
+[MIT](https://tldrlegal.com/license/mit-license)

--- a/test/fixture-out.css
+++ b/test/fixture-out.css
@@ -13,23 +13,26 @@
 #hello-world { color: green; }
 #hello-world:hover { color: blue; }
 
-#hello-world h1 {}
-#hello-world h1.title {}
-#hello-world h2#thing {}
-#hello-world #thing h3 {}
+h1 {}
+h1.title {}
+h2#thing {}
+#thing h3 {}
 
-#hello-world .a, #hello-world .b, #hello-world .c {}
+.a, .b, .c {}
 
 @media screen and (max-width: 42rem) {
-  #hello-world #another .thing > x-here {}
+  #hello-world {
+    .thing > x-here {}
+  }
+  #another .thing > x-here {}
 }
 
-#hello-world .stuff:nth-child(even) {}
+.stuff:nth-child(even) {}
 
-#hello-world .stuff:nth-last-child(even) {}
+.stuff:nth-last-child(even) {}
 
-#hello-world .stuff:nth-of-type(2) {}
+.stuff:nth-of-type(2) {}
 
-#hello-world .stuff:nth-last-of-type(2) {}
+.stuff:nth-last-of-type(2) {}
 
-#hello-world .stuff:not(#hello-world p) {}
+.stuff:not(p) {}

--- a/test/fixture.css
+++ b/test/fixture.css
@@ -21,6 +21,9 @@ h2#thing {}
 .a, .b, .c {}
 
 @media screen and (max-width: 42rem) {
+  :host {
+    .thing > x-here {}
+  }
   #another .thing > x-here {}
 }
 


### PR DESCRIPTION
Aka add support for globals when running this plugin. Everyone I know that's running this package uses the `:host` prefix anyway to signal what they're doing, and yeah I get it because it's definitely easier to explain so figured we might as well make it the formal API. New feature, cleaner results :sparkles:

Mos def a semver major