### PR TITLE
Add support for :host-context

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,12 @@ function postcssPrefix (prefix, options) {
         const replacement = Selector.selector()
         replacement.nodes = [prefixNode].concat(selector.clone().nodes)
         selector.replaceWith(replacement)
+      } else if (selector.type === 'pseudo' && selector.value === ':host-context') {
+        const prefixNode = getPrefixNode(prefix)
+        const replacement = Selector.selector()
+        const prevNodes = selector.clone().nodes
+        replacement.nodes = prevNodes.concat(' ', prefixNode, ', ', prefixNode, prevNodes)
+        selector.replaceWith(replacement)
       }
     })
   }

--- a/test/fixture-out.css
+++ b/test/fixture-out.css
@@ -13,6 +13,8 @@
 #hello-world { color: green; }
 #hello-world:hover { color: blue; }
 
+#hello-world.test { color: aqua; }
+
 .test #hello-world, #hello-world.test { color: red; }
 
 h1 {}

--- a/test/fixture-out.css
+++ b/test/fixture-out.css
@@ -13,6 +13,8 @@
 #hello-world { color: green; }
 #hello-world:hover { color: blue; }
 
+.test #hello-world, #hello-world.test { color: red; }
+
 h1 {}
 h1.title {}
 h2#thing {}

--- a/test/fixture.css
+++ b/test/fixture.css
@@ -13,6 +13,8 @@
 :host { color: green; }
 :host(:hover) { color: blue; }
 
+:host-context(.test) { color: red; }
+
 h1 {}
 h1.title {}
 h2#thing {}

--- a/test/fixture.css
+++ b/test/fixture.css
@@ -13,6 +13,8 @@
 :host { color: green; }
 :host(:hover) { color: blue; }
 
+:host(.test) { color: aqua; }
+
 :host-context(.test) { color: red; }
 
 h1 {}


### PR DESCRIPTION
From: https://www.html5rocks.com/en/tutorials/webcomponents/shadowdom-201/#toc-style-host

> The `:host-context(<selector>)` pseudo class matches the host element if it or any of its ancestors matches <selector>.

> A common use of `:host-context()` is for theming an element based on its surrounds. For example, many people do theming by applying a class to `<html>` or `<body>`

This is useful for me for styling with [sheetify](https://github.com/stackcss/sheetify) when I need to change styles based on context.
